### PR TITLE
Use Bors for CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,7 +1,11 @@
 name: CI
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+      - master
+      - staging
+      - trying
+    tags: '*'
 jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ AWSClusterManagers
 ==================
 
 [![CI](https://github.com/JuliaCloud/AWSClusterManagers.jl/workflows/CI/badge.svg)](https://github.com/JuliaCloud/AWSClusterManagers.jl/actions?query=workflow%3ACI)
+[![Bors enabled](https://bors.tech/images/badge_small.svg)](https://app.bors.tech/repositories/32323)
 [![codecov](https://codecov.io/gh/JuliaCloud/AWSClusterManagers.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/JuliaCloud/AWSClusterManagers.jl)
 [![Stable Documentation](https://img.shields.io/badge/docs-stable-blue.svg)](https://juliacloud.github.io/AWSClusterManagers.jl/stable)
 

--- a/bors.toml
+++ b/bors.toml
@@ -1,0 +1,10 @@
+
+status = [
+    "Julia 1.0 - ubuntu-latest - x64",
+    "Julia 1.0 - ubuntu-latest - x86",
+    "Julia 1.0 - macOS-latest - x64",
+    "Julia 1 - ubuntu-latest - x64",
+    "Julia 1 - ubuntu-latest - x86",
+    "Julia 1 - macOS-latest - x64",
+]
+delete-merged-branches = true


### PR DESCRIPTION
In order to allow this repo to use the AWS account to enable online testing I first need to restrict access to who can execute CI jobs.